### PR TITLE
Fix language switching code

### DIFF
--- a/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/MainActivity.kt
+++ b/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/MainActivity.kt
@@ -18,13 +18,11 @@ import de.sudoq.R
 import de.sudoq.controller.SudoqCompatActivity
 import de.sudoq.controller.menus.preferences.LanguageSetting
 import de.sudoq.controller.menus.preferences.LanguageUtility.getConfLocale
-import de.sudoq.controller.menus.preferences.LanguageUtility.loadLanguageFromLocale
-import de.sudoq.controller.menus.preferences.LanguageUtility.loadLanguageFromSharedPreferences2
+import de.sudoq.controller.menus.preferences.LanguageUtility.loadLanguageFromSharedPreferences
 import de.sudoq.controller.menus.preferences.LanguageUtility.setConfLocale
-import de.sudoq.controller.menus.preferences.LanguageUtility.storeLanguageToMemory2
+import de.sudoq.controller.menus.preferences.LanguageUtility.storeLanguageToSharedPreferences
 import de.sudoq.controller.menus.preferences.PlayerPreferencesActivity
 import de.sudoq.controller.sudoku.SudokuActivity
-import de.sudoq.model.profile.ProfileSingleton
 import de.sudoq.model.profile.ProfileManager
 import de.sudoq.persistence.profile.ProfileRepo
 import de.sudoq.persistence.profile.ProfilesListRepo
@@ -62,22 +60,14 @@ class MainActivity : SudoqCompatActivity() {
         /* load language from profile */
 
         //retrieve language from profile at beginning of activity lifecycle
-        currentLanguageCode = loadLanguageFromSharedPreferences2(this)
-        val a = Locale.getDefault().language
-        val b = resources.configuration.locale.language
-        val c = currentLanguageCode!!.toStorableString()
-        if (currentLanguageCode!!.isSystemLanguage) {
-            //nothing to do
-            //locale is adopted automatically from device
-        } else {
-            val currentConf = getConfLocale(this)
-            if (currentConf != currentLanguageCode!!.language) {
-                //if conf != loaded language, set conf and update
-                setConfLocale(currentLanguageCode!!.language.name, this)
-                val refresh = Intent(this, this.javaClass)
-                finish()
-                this.startActivity(refresh)
-            }
+        currentLanguageCode = loadLanguageFromSharedPreferences(this)
+        val currentConf = getConfLocale(this)
+        if (currentConf != currentLanguageCode!!.language.name) {
+            // if conf != loaded language, set conf and update
+            setConfLocale(currentLanguageCode!!.language.name, this)
+            val refresh = Intent(this, this.javaClass)
+            finish()
+            this.startActivity(refresh)
         }
         Log.d("lang", "MainActivity.onCreate() set with $currentLanguageCode")
     }
@@ -100,7 +90,7 @@ class MainActivity : SudoqCompatActivity() {
 
         //load language from memory
         val fromConf = getConfLocale(this)
-        if (fromConf != currentLanguageCode!!.language) {
+        if (fromConf != currentLanguageCode!!.language.name) {
             //language has been changed so we need to restart this activity
             //so that the new language is applied to it
             Log.d("lang", "refresh because $currentLanguageCode -> $fromConf")
@@ -150,9 +140,9 @@ class MainActivity : SudoqCompatActivity() {
             //only adopt external change if language is set to "system language"
             if (currentLanguageCode!!.isSystemLanguage) {
                 //adopt change
-                currentLanguageCode!!.language = loadLanguageFromLocale()
+                currentLanguageCode = loadLanguageFromSharedPreferences(this)
                 //store changes
-                storeLanguageToMemory2(this, currentLanguageCode!!)
+                storeLanguageToSharedPreferences(this, currentLanguageCode!!)
             }
         }
     }

--- a/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/preferences/AdvancedPreferencesActivity.kt
+++ b/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/preferences/AdvancedPreferencesActivity.kt
@@ -18,7 +18,6 @@ import android.widget.AdapterView.OnItemSelectedListener
 import androidx.appcompat.widget.Toolbar
 import de.sudoq.R
 import de.sudoq.controller.menus.NewSudokuActivity
-import de.sudoq.controller.menus.preferences.AdvancedPreferencesActivity
 import de.sudoq.controller.menus.preferences.LanguageSetting.LanguageCode
 import de.sudoq.model.game.GameSettings
 import de.sudoq.model.profile.ProfileManager
@@ -108,7 +107,7 @@ class AdvancedPreferencesActivity : PreferencesActivity() {
         val thishere: Activity = this
 
         //set language
-        currentLanguageCode = LanguageUtility.loadLanguageFromSharedPreferences2(this)
+        currentLanguageCode = LanguageUtility.loadLanguageFromSharedPreferences(this)
         Log.d(
             "lang",
             "set language to AdvancedPreferencesActivity.onCreate() after setLocaleFromMemory."
@@ -135,7 +134,7 @@ class AdvancedPreferencesActivity : PreferencesActivity() {
                 //enum to string(resolving system language) and set
                 val newCode = LanguageUtility.getLanguageFromItem(enumCode)
                 LanguageUtility.setConfLocale(newCode.language.name, thishere)
-                LanguageUtility.storeLanguageToMemory2(this@AdvancedPreferencesActivity, newCode)
+                LanguageUtility.storeLanguageToSharedPreferences(this@AdvancedPreferencesActivity, newCode)
                 //int previous = LanguageUtility.loadLanguageFromConf(AdvancedPreferencesActivity.this).name();
                 if (currentLanguageCode!!.language != newCode.language) {
                     //if we change e.g. from system(english) to english we need to store a different value but we don't need to refresh.

--- a/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/preferences/PlayerPreferencesActivity.kt
+++ b/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/preferences/PlayerPreferencesActivity.kt
@@ -68,7 +68,7 @@ class PlayerPreferencesActivity : PreferencesActivity() {
         p.registerListener(this)
 
         //store language at beginning of activity lifecycle
-        currentLanguageCode = LanguageUtility.loadLanguageFromSharedPreferences2(this)
+        currentLanguageCode = LanguageUtility.loadLanguageFromSharedPreferences(this)
     }
 
     override fun onResume() {
@@ -77,7 +77,7 @@ class PlayerPreferencesActivity : PreferencesActivity() {
         //load language from memory
         //LanguageSetting fromMemory = LanguageUtility.loadLanguageFromSharedPreferences2(this);
         val fromConf = LanguageUtility.getConfLocale(this)
-        if (fromConf != currentLanguageCode!!.language) {
+        if (fromConf != currentLanguageCode!!.language.name) {
             val refresh = Intent(this, this.javaClass)
             finish()
             this.startActivity(refresh)
@@ -95,9 +95,9 @@ class PlayerPreferencesActivity : PreferencesActivity() {
             //only adopt external change if language is set to "system language"
             if (currentLanguageCode!!.isSystemLanguage) {
                 //adopt change
-                currentLanguageCode!!.language = LanguageUtility.loadLanguageFromLocale()
+                currentLanguageCode = LanguageUtility.loadLanguageFromSharedPreferences(this)
                 //store changes
-                LanguageUtility.storeLanguageToMemory2(this, currentLanguageCode!!)
+                LanguageUtility.storeLanguageToSharedPreferences(this, currentLanguageCode!!)
             }
         }
     }


### PR DESCRIPTION
This pull request fixes SudoQ with unsupported locales (like Dutch)

With the current master I was able to crash SudoQ like this:

- set phone locale to Dutch (no other languages in the language list)
- stop SudoQ
- clear data of SudoQ
- start SudoQ

The crash can be reproduced in the emulator too.

The result is and endless loop that constantly terminates / restarts the MainActivity. It is difficult to terminate SudoQ while in this state.

My patch fixes this crash. I also did some basic tests. The language switching behaviour seems to be correct