### PR TITLE
Fix crash when trying to restrict offered Sudoku types

### DIFF
--- a/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/preferences/RestrictTypesActivity.kt
+++ b/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/preferences/RestrictTypesActivity.kt
@@ -156,6 +156,7 @@ class RestrictTypesActivity : SudoqListActivity(), OnItemClickListener, OnItemLo
     private fun initialiseTypes() {
         val profilesDir = getDir(getString(R.string.path_rel_profiles), MODE_PRIVATE)
         val pm = ProfileManager(profilesDir, ProfileRepo(profilesDir), ProfilesListRepo(profilesDir))
+        pm.loadCurrentProfile()
         types = pm.assistances.wantedTypesList
         // initialize ArrayAdapter for the type names and set it
         adapter = RestrictTypesAdapter(this, types!!)


### PR DESCRIPTION
Changed method attempts to use the current profile, but did not load it.
Results in a crash (NPE) whenever attempting to restrict offered Sudoku types.