### PR TITLE
Fix crash when orientation changes

### DIFF
--- a/fastlane/metadata/android/de-DE/changelogs/41.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/41.txt
@@ -1,0 +1,1 @@
+Fixt NPE bei Orientierungswechsel. Danke Ecconia!

--- a/fastlane/metadata/android/en-US/changelogs/41.txt
+++ b/fastlane/metadata/android/en-US/changelogs/41.txt
@@ -1,0 +1,1 @@
+Fix NPE on orientation change. Thanks Ecconia!

--- a/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/NewSudokuActivity.kt
+++ b/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/NewSudokuActivity.kt
@@ -90,7 +90,7 @@ class NewSudokuActivity : SudoqCompatActivity() {
 
         // nested Listener for complexitySpinner
         complexitySpinner.onItemSelectedListener = object : OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>?, view: View, pos: Int, id: Long) {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, pos: Int, id: Long) {
                 setSudokuDifficulty(Complexity.values()[pos])
             }
 

--- a/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/preferences/AdvancedPreferencesActivity.kt
+++ b/sudoq-app/sudoqapp/src/main/kotlin/de/sudoq/controller/menus/preferences/AdvancedPreferencesActivity.kt
@@ -115,7 +115,7 @@ class AdvancedPreferencesActivity : PreferencesActivity() {
         languageSpinner.setSelection(if (currentLanguageCode!!.isSystemLanguage) 0 else currentLanguageCode!!.language.ordinal)
         // nested Listener for languageSpinner
         languageSpinner.onItemSelectedListener = object : OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>?, view: View, pos: Int, id: Long) {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, pos: Int, id: Long) {
                 var pos = pos
                 if (langSpinnerInit) {
                     //onitemselected is called after initialization


### PR DESCRIPTION
When changing the orientation the 'view' parameter may be 'null' for a call.
Kotlin declared 'view' as non-null though, hence Kotlin runtime crashed (or so). Causing the app to crash and show the main screen again.
Allowing 'null' fixes this crash.